### PR TITLE
fix: failed to build in release CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "node ./bin.js",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "bump": "npx bumpp"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "dev": "rslib build --watch",
     "prebundle": "node ./bin.js",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build",
     "bump": "npx bumpp"
   },
   "dependencies": {


### PR DESCRIPTION
The npm-publish action do not run `prepublishOnly`.

https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#v2-behavior-changes