### PR TITLE
feat: add new `copyDts` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ export default {
 };
 ```
 
+### copyDts
+
+Copy all type definitions files rather than bundle them via `rollup-plugin-dts`.
+
+```ts
+// prebundle.config.mjs
+export default {
+  dependencies: [{ name: 'foo', copyDts: true }],
+};
+```
+
 ### target
 
 Target ECMAScript version, default `es2021`.

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -72,6 +72,7 @@ export function parseTasks(
         minify: dep.minify ?? false,
         target: dep.target ?? 'es2019',
         ignoreDts: dep.ignoreDts,
+        copyDts: dep.copyDts,
         externals: dep.externals ?? {},
         dtsExternals: dep.dtsExternals ?? [],
         emitFiles: dep.emitFiles ?? [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export type DependencyConfig = {
   packageJsonField?: string[];
   /** Whether to ignore type definitions */
   ignoreDts?: boolean;
+  /** Whether to copy all type definitions files rather than bundle them */
+  copyDts?: boolean;
   /** Target ECMA version */
   target?: string;
   /* Callback before bundle. */
@@ -45,6 +47,7 @@ export type ParsedTask = {
   distPath: string;
   importPath: string;
   ignoreDts?: boolean;
+  copyDts?: boolean;
   prettier?: boolean;
   target: NonNullable<DependencyConfig['target']>;
   minify: NonNullable<DependencyConfig['minify']>;


### PR DESCRIPTION
Add new `copyDts` option to copy all type definitions files rather than bundle them via `rollup-plugin-dts`.