### PR TITLE
fix: include .d.cts files in dts copy pattern

### DIFF
--- a/src/prebundle.ts
+++ b/src/prebundle.ts
@@ -73,7 +73,7 @@ async function emitDts(task: ParsedTask, externals: Record<string, string>) {
   }
 
   if (task.copyDts) {
-    const dtsFiles = fastGlob.sync('**/*.d.ts', {
+    const dtsFiles = fastGlob.sync('**/*.d.{ts,cts}', {
       cwd: task.depPath,
       absolute: false,
     });


### PR DESCRIPTION
Update the fast-glob pattern to also copy `.d.cts` files when copying type definitions.