### PR TITLE
test: revert color workaround from @rstest/core 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.0",
     "@rslib/core": "0.19.4",
-    "@rstest/core": "^0.8.2",
+    "@rstest/core": "^0.8.3",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.8",
     "chalk": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: 0.19.4
         version: 0.19.4(typescript@5.9.3)
       '@rstest/core':
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.8.3
+        version: 0.8.3
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -334,11 +334,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.7.2':
-    resolution: {integrity: sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-
   '@rsbuild/core@1.7.3':
     resolution: {integrity: sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==}
     engines: {node: '>=18.12.0'}
@@ -425,8 +420,8 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
-  '@rstest/core@0.8.2':
-    resolution: {integrity: sha512-l//JT7cfrSk3LMxwqW9wuCEECpVFS2Cux1QN3BQl6mVLNzZMzZPtSS/pv2NNZKFDHfmdmq59fe3g8XP0ekDeOw==}
+  '@rstest/core@0.8.3':
+    resolution: {integrity: sha512-KNBCrqeYhyU5/D20zyyEeOHjsx2AD6E3j6kY9FxMRkFEq+Dnhm1V35X1yi4jTyUzpIKgK/roLeLYAOBlBmg+lA==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -881,14 +876,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
-  '@rsbuild/core@1.7.2':
-    dependencies:
-      '@rspack/core': 1.7.5(@swc/helpers@0.5.18)
-      '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.18
-      core-js: 3.47.0
-      jiti: 2.6.1
-
   '@rsbuild/core@1.7.3':
     dependencies:
       '@rspack/core': 1.7.5(@swc/helpers@0.5.18)
@@ -961,9 +948,9 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rstest/core@0.8.2':
+  '@rstest/core@0.8.3':
     dependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 1.7.3
       '@types/chai': 5.2.3
       tinypool: 1.1.1
 

--- a/tests/prebundle.test.ts
+++ b/tests/prebundle.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, rs } from '@rstest/core';
+import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
 import { execFile } from 'node:child_process';
 import { promises as fs, readdirSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
@@ -19,13 +19,11 @@ const targetPackages: TargetPackage[] = [
   {
     name: 'chalk',
     verify: async (distPath: string) => {
-      rs.stubEnv('FORCE_COLOR', '1');
       const mod = await loadBundledModule(distPath);
       const chalkInstance = mod.default ?? mod;
       const message = chalkInstance.hex('#00ff88')('prebundle-ready');
       expect(message).toContain('prebundle-ready');
       expect(message).toContain('\u001b[');
-      rs.unstubAllEnvs();
     },
   },
   {


### PR DESCRIPTION
revert color workaround from @rstest/core 0.8.2, just like before.