### PR TITLE
chore: upgrade TypeScript to ^6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "rslib",
     "dev": "rslib -w",
     "prebundle": "node ./bin.js",
-    "prepare": "npm run build",
+    "prepare": "rslib",
     "bump": "npx bumpp",
     "test": "rstest"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.4",
     "rslog": "^1.3.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "packageManager": "pnpm@10.33.0",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 4.60.0
       rollup-plugin-dts:
         specifier: ^6.4.1
-        version: 6.4.1(rollup@4.60.0)(typescript@5.9.3)
+        version: 6.4.1(rollup@4.60.0)(typescript@6.0.2)
       terser:
         specifier: ^5.46.1
         version: 5.46.1
@@ -32,7 +32,7 @@ importers:
         version: 3.7.2
       '@rslib/core':
         specifier: 0.20.1
-        version: 0.20.1(core-js@3.47.0)(typescript@5.9.3)
+        version: 0.20.1(core-js@3.47.0)(typescript@6.0.2)
       '@rstest/core':
         specifier: ^0.9.5
         version: 0.9.5(core-js@3.47.0)
@@ -55,8 +55,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -633,8 +633,8 @@ packages:
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -851,12 +851,12 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.20.1(core-js@3.47.0)(typescript@5.9.3)':
+  '@rslib/core@0.20.1(core-js@3.47.0)(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.10(core-js@3.47.0)
-      rsbuild-plugin-dts: 0.20.1(@rsbuild/core@2.0.0-beta.10(core-js@3.47.0))(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.20.1(@rsbuild/core@2.0.0-beta.10(core-js@3.47.0))(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
@@ -1052,14 +1052,14 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rollup-plugin-dts@6.4.1(rollup@4.60.0)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.60.0)(typescript@6.0.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.60.0
-      typescript: 5.9.3
+      typescript: 6.0.2
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 
@@ -1094,12 +1094,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.20.1(@rsbuild/core@2.0.0-beta.10(core-js@3.47.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.1(@rsbuild/core@2.0.0-beta.10(core-js@3.47.0))(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-beta.10(core-js@3.47.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   rslog@1.3.2: {}
 
@@ -1140,7 +1140,7 @@ snapshots:
 
   tslib@2.8.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}
 

--- a/tests/prebundle.test.ts
+++ b/tests/prebundle.test.ts
@@ -20,7 +20,9 @@ const targetPackages: TargetPackage[] = [
     name: 'chalk',
     verify: async (distPath: string) => {
       const mod = await loadBundledModule(distPath);
-      const chalkInstance = mod.default ?? mod;
+      const chalkInstance = mod.Chalk
+        ? new mod.Chalk({ level: 1 })
+        : (mod.default ?? mod);
       const message = chalkInstance.hex('#00ff88')('prebundle-ready');
       expect(message).toContain('prebundle-ready');
       expect(message).toContain('\u001b[');
@@ -94,7 +96,7 @@ function readRelativeFileTree(distPath: string) {
 
 async function loadBundledModule(distPath: string) {
   const moduleUrl = pathToFileURL(join(distPath, 'index.js'));
-  return import(moduleUrl.href);
+  return import(`${moduleUrl.href}?t=${Date.now()}`);
 }
 
 async function runPrebundle() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,15 @@
 {
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./dist",
-    "target": "ES2021",
+    "target": "ES2023",
+    "types": ["node"],
     "lib": ["DOM", "ESNext"],
-    "allowJs": true,
-    "strict": true,
     "declaration": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
-    "jsx": "preserve",
-    "resolveJsonModule": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- upgrade TypeScript to `^6.0.2` and keep the existing tsconfig update
- make the bundled `chalk` smoke test deterministic by constructing a `Chalk` instance with an explicit color level instead of relying on the host terminal environment

## Testing
- `pnpm i`
- `pnpm build`
- `pnpm test`

## Related Links
- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2
