### PR TITLE
chore: add Rslint linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run lint
+        run: pnpm lint
+
       - name: Run tests
         run: pnpm test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["rstack.rslint"]
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "build": "rslib",
     "dev": "rslib -w",
+    "lint": "rslint",
+    "lint:write": "rslint --fix",
     "prebundle": "node ./bin.js",
     "prepare": "rslib",
     "bump": "npx bumpp",
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.2",
     "@rslib/core": "0.21.3",
+    "@rslint/core": "^0.5.2",
     "@rstest/core": "^0.9.10",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "24.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@rslib/core':
         specifier: 0.21.3
         version: 0.21.3(core-js@3.47.0)(typescript@6.0.3)
+      '@rslint/core':
+        specifier: ^0.5.2
+        version: 0.5.2
       '@rstest/core':
         specifier: ^0.9.10
         version: 0.9.10(core-js@3.47.0)
@@ -345,6 +348,45 @@ packages:
       typescript:
         optional: true
 
+  '@rslint/core@0.5.2':
+    resolution: {integrity: sha512-RDP0uvg0ni1AXl/Jq9LglY8QmSIuM4HN4Lx9Pef6xL1QZrgXkQJ5GKPlBjkbMDu7Zdlfjo1L5D1S0cttaEjBHA==}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  '@rslint/darwin-arm64@0.5.2':
+    resolution: {integrity: sha512-gu7WyZnyZt9x/TMC+jtf0LYTC0Zq9Fq38utef5dcm8iVbdZNqt+EnwrOqVFaqI1ikYC18IOi9aIe7/bxVZp/aA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rslint/darwin-x64@0.5.2':
+    resolution: {integrity: sha512-sxvIAWldUBd/EeK+PkQhgVbRq6VwHBmUNxKNWyng5zL0gWu02X8ynhyzDgWfUKPXH7BgebSItQBfa4+qFQXhUw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rslint/linux-arm64@0.5.2':
+    resolution: {integrity: sha512-D8cmoMDqzwZqELtxbVZDX0jGMXkSwAejvOL9D1GXoFAxq74xuT/s0UdfbkzZtAAvIFrwa8PGskPXv3X/1w2WbA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rslint/linux-x64@0.5.2':
+    resolution: {integrity: sha512-b4Nato9LgkPX7OydaeXexUUvkfm4+tRAvp46T4xhe76k136/ziImRPBcM/G7pBNyaV5Rd6qp6CiYW330Q+0Gnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rslint/win32-arm64@0.5.2':
+    resolution: {integrity: sha512-3pfpABHaBv+Z551cKOX+pVllmGFJc7dLHDs2XignLxZ89xsxomlAx8CLhkaDECUkoBM7gj4/oQr57t9Ndhe3Lw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rslint/win32-x64@0.5.2':
+    resolution: {integrity: sha512-MnIp0ofyg7AXP+bgt1VW1ejJszkgyFKHJvSqZ3QePOllWKXA7Nhj4lMIluIcTN1D4C0f00+6POYOeIjSwI+aRQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-darwin-arm64@2.0.1':
     resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==}
     cpu: [arm64]
@@ -500,6 +542,15 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -555,6 +606,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -625,6 +680,10 @@ packages:
     resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
@@ -866,6 +925,36 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
+  '@rslint/core@0.5.2':
+    dependencies:
+      picomatch: 4.0.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.5.2
+      '@rslint/darwin-x64': 0.5.2
+      '@rslint/linux-arm64': 0.5.2
+      '@rslint/linux-x64': 0.5.2
+      '@rslint/win32-arm64': 0.5.2
+      '@rslint/win32-x64': 0.5.2
+
+  '@rslint/darwin-arm64@0.5.2':
+    optional: true
+
+  '@rslint/darwin-x64@0.5.2':
+    optional: true
+
+  '@rslint/linux-arm64@0.5.2':
+    optional: true
+
+  '@rslint/linux-x64@0.5.2':
+    optional: true
+
+  '@rslint/win32-arm64@0.5.2':
+    optional: true
+
+  '@rslint/win32-x64@0.5.2':
+    optional: true
+
   '@rspack/binding-darwin-arm64@2.0.1':
     optional: true
 
@@ -1000,6 +1089,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -1051,6 +1144,8 @@ snapshots:
     optional: true
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.4: {}
 
   prettier@3.8.3: {}
 
@@ -1137,6 +1232,11 @@ snapshots:
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@2.1.0: {}
 

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, js, ts } from '@rslint/core';
+
+export default defineConfig([
+  {
+    ignores: ['compiled/**'],
+  },
+  js.configs.recommended,
+  ts.configs.recommended,
+]);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -20,7 +20,7 @@ export function findDepPath(name: string) {
     }
 
     return entry;
-  } catch (err) {
+  } catch {
     return null;
   }
 }
@@ -156,7 +156,9 @@ export function findDirectTypeFile(filepath: string) {
     for (const f of list) {
       try {
         return require.resolve(f, { paths: [cwd] });
-      } catch {}
+      } catch {
+        continue;
+      }
     }
   };
   switch (ext) {

--- a/src/prebundle.ts
+++ b/src/prebundle.ts
@@ -53,13 +53,30 @@ async function emitIndex(code: string, distPath: string, prettier?: boolean) {
   }
 }
 
-const getTypes = (json: Record<string, string>): string | null =>
+type PackageJsonLike = {
+  types?: unknown;
+  typing?: unknown;
+  typings?: unknown;
+  exports?: {
+    '.'?: PackageJsonLike;
+  };
+};
+
+const getPackageJsonField = (
+  json: PackageJsonLike,
+  key: 'types' | 'typing' | 'typings',
+) => {
+  const value = json[key];
+  return typeof value === 'string' ? value : null;
+};
+
+const getTypes = (json: PackageJsonLike | null | undefined): string | null =>
   (json &&
-    (json.types ||
-      json.typing ||
-      json.typings ||
+    (getPackageJsonField(json, 'types') ||
+      getPackageJsonField(json, 'typing') ||
+      getPackageJsonField(json, 'typings') ||
       // for those who use `exports` only
-      getTypes((json as any).exports?.['.']))) ||
+      getTypes(json.exports?.['.']))) ||
   null;
 
 async function emitDts(task: ParsedTask, externals: Record<string, string>) {
@@ -145,7 +162,7 @@ async function emitDts(task: ParsedTask, externals: Record<string, string>) {
             // Avoid extra work
             checkJs: false,
             // Ensure we can parse the latest code
-            // @ts-expect-error
+            // @ts-expect-error rollup-plugin-dts accepts task target values.
             target: task.target,
           },
         }),
@@ -210,7 +227,9 @@ function emitPackageJson(
         // will be `{"type":"module"}` if the output is of esm format
         pick(JSON.parse(assets['package.json'].source), ['type']),
       );
-    } catch {}
+    } catch {
+      // Keep the picked package fields when ncc emits non-JSON metadata.
+    }
   }
 
   fs.outputFileSync(outputPath, JSON.stringify(pickedPackageJson, null, 2));


### PR DESCRIPTION
## Summary

This PR adds Rslint as the repository linter so lint issues are caught locally and in CI. It adds the Rslint JS/TS recommended config, lint scripts, the VS Code extension recommendation, and a CI lint step before tests. It also cleans up the existing source issues required by the recommended rules.