### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lint": "rslint",
     "lint:write": "rslint --fix",
     "prebundle": "node ./bin.js",
-    "prepare": "rslib",
     "bump": "npx bumpp",
     "test": "rstest"
   },


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove duplicate build commands from `scripts.prepare` where present.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.