### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@astrojs/sitemap": "^3.7.3",
     "@rslib/core": "0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.10.6",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.10.6
         version: 0.10.6
@@ -573,6 +576,9 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.10.6':
     resolution: {integrity: sha512-nX61dw2Tnxfwy/jGZEuNbh2tzapgaH6Iwj4Aw5d2wxUwxptUL3ddUxFF5M1ZSWoLEVG30VaPg3ITzrSo5sdbTg==}
@@ -1205,6 +1211,8 @@ snapshots:
       '@rspack/binding': 2.1.2
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.10.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
   core-js: false
 minimumReleaseAgeExclude:
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   core-js: false
+minimumReleaseAgeExclude:
+  - '@rstackjs/test-utils@0.2.0'

--- a/tests/prebundle.test.ts
+++ b/tests/prebundle.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import { prepareDist } from '@rstackjs/test-utils';
 import { execFile } from 'node:child_process';
-import { promises as fs, readdirSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
@@ -46,14 +47,14 @@ beforeAll(async () => {
   for (const target of targetPackages) {
     const distPath = join(process.cwd(), 'compiled', target.name);
     bundledPaths.set(target.name, distPath);
-    await resetDist(distPath);
+    await prepareDist(distPath);
   }
   await runPrebundle();
 });
 
 afterAll(async () => {
   for (const distPath of bundledPaths.values()) {
-    await resetDist(distPath);
+    await prepareDist(distPath);
   }
 });
 
@@ -66,13 +67,6 @@ describe('prebundle integration smoke tests', () => {
     await assertBundledPackage('@astrojs/sitemap');
   });
 });
-
-async function resetDist(distPath?: string) {
-  if (!distPath) {
-    return;
-  }
-  await fs.rm(distPath, { recursive: true, force: true });
-}
 
 function readRelativeFileTree(distPath: string) {
   const results: string[] = [];


### PR DESCRIPTION
This PR replaces the local test output cleanup helper with `prepareDist` from `@rstackjs/test-utils`, keeping common filesystem test behavior maintained in one package.